### PR TITLE
Anibel - Edges - Matrix Convert to Zero

### DIFF
--- a/lib/matrix_convert_to_zero.rb
+++ b/lib/matrix_convert_to_zero.rb
@@ -3,5 +3,29 @@
 # If any number is found to be 0, the method updates all the numbers in the
 # corresponding row as well as the corresponding column to be 0.
 def matrix_convert_to_0(matrix)
-  raise NotImplementedError
+
+  rows = matrix.length
+  columns = matrix[0].length
+
+  zeroes = {}
+
+  rows.times do |r|
+    columns.times do |c|
+      if matrix[r][c] == 0
+        zeroes[r] = c
+      end
+    end
+  end
+
+  zeroes.each do |row, column|
+    rows.times do |r|
+      if row == r
+        columns.times do |num|
+          matrix[r][num] = 0
+        end
+      end
+      matrix[r][column] = 0
+    end
+  end
+
 end

--- a/lib/matrix_convert_to_zero.rb
+++ b/lib/matrix_convert_to_zero.rb
@@ -7,25 +7,31 @@ def matrix_convert_to_0(matrix)
   rows = matrix.length
   columns = matrix[0].length
 
-  zeroes = {}
+  rows.times do |r|
+    matrix[r].each_with_index do |num, column|
+      if num == 0
+        matrix[r][0] = 0
+        matrix[0][column] = 0
+      end
+    end
+  end
 
   rows.times do |r|
     columns.times do |c|
-      if matrix[r][c] == 0
-        zeroes[r] = c
-      end
-    end
-  end
-
-  zeroes.each do |row, column|
-    rows.times do |r|
-      if row == r
-        columns.times do |num|
-          matrix[r][num] = 0
+      unless r == 0 || c == 0
+        if matrix[r][0] == 0 || matrix[0][c] == 0
+          matrix[r][c] = 0
         end
       end
-      matrix[r][column] = 0
     end
   end
 
+  if matrix[0][0] == 0
+    columns.times do |c|
+      matrix[0][c] = 0
+    end
+    rows.times do |r|
+      matrix[r][0] = 0
+    end
+  end
 end


### PR DESCRIPTION
Time complexity: `O(n * m)` where `n` is the length of the rows and `m` is the length of the columns. Since we first iterate through each value in the matrix to find the zeroes once, then loop again to convert the 2nd row/column onward to appropriate values, and then finally convert the 1st row and column if necessary, the time complexity is actually `O(2 * n * m)` but we drop the constants to get `O(n * m)`.

The space complexity is constant at `O(1)` since we are setting aside a constant amount of space to hold integer values (dimensions of the matrix) regardless of input matrix. Initially, I had a hash to store these but using the first row and column to mark the necessary rows/columns for zeroing out reduced the space requirements.